### PR TITLE
Added Italian translation

### DIFF
--- a/docs/multilingual.md
+++ b/docs/multilingual.md
@@ -12,8 +12,10 @@ Feri is currently available in the following languages.
  * English (US)
  * French (France)
  * German (Germany and Switzerland)
+ * Italian (Italy and Switzerland)
  * Portuguese (Brazil)
  * Swedish (Sweden)
+
 
 Don't see your favorite language? Check out the [translation guide](#translation-guide) to see how you can help.
 

--- a/language/it-it.json
+++ b/language/it-it.json
@@ -1,0 +1,49 @@
+{
+    "error": {
+        "configPaths"           : "Sorgente e destinazione dovrebbero essere univoche e non innestate l'una nell'altra.",
+        "destPointsToSource"    : "La destinazione punta ad una cartella sorgente.",
+        "destProtected"         : "La destinazione non dovrebbe essere una locazione protetta come {path}.",
+        "halted"                : "{software} versione {version} interrotto a causa di errori.",
+        "missingDest"           : "File destinazione mancante.",
+        "missingSource"         : "File sorgente mancante.",
+        "missingSourceDirectory": "Cartella sorgente mancante.",
+        "removeDest"            : "Cancellazione file sorgente ignorata poiché i file sorgente non dovrebbero mai essere toccati.",
+        "watchingDest"          : "Errore monitorando la cartella destinazione.",
+        "watchingSource"        : "Errore monitorando la cartella sorgente."
+    },
+    "message": {
+        "fileChangedTooRecently"  : "{file} è stato modificato troppo recentemente, verrà ignorato.",
+        "includesNewer"           : "File {extension} inclusi più recenti rispetto ai file destinazione.",
+        "missingSourceToDestTasks": "config.map.sourceToDestTasks mancante per i seguenti tipi di file:",
+        "listeningOnPort"         : "{software} in ascolto sulla porta {port}.",
+        "usingConfigFile"         : "Utilizzando il file {file}.",
+        "watchRefreshed"          : "{software} aggiornato.",
+        "watchingDirectory"       : "Monitorando cambiamenti in {directory}."
+    },
+    "paddedGroups": {
+        "build": {
+            "output": "output",
+            "copy"  : "copia "
+        },
+        "stats": {
+            "load" : "Caricamento ",
+            "clean": "Pulizia     ",
+            "build": "Assemblaggio",
+            "watch": "Monitoraggio",
+            "total": "Totale      "
+        }
+    },
+    "words": {
+        "add"      : "aggiunto",
+        "build"    : "Assemblaggio",
+        "clean"    : "Pulizia",
+        "change"   : "modificato",
+        "directory": "cartella",
+        "done"     : "Fatto",
+        "removed"  : "rimosso",
+        "seconds"  : "secondi",
+        "stats"    : "Statistiche",
+        "watch"    : "Monitora",
+        "watching" : "Monitorando"
+    }
+}


### PR DESCRIPTION
There could be some minor problems with certain words and gender agreement, for example `add` / `removed` & `directory`.

Suppose a file is added: in English `<file> add` is shown while in Italian `<file> aggiunto` ("file" is a masculine noun in Italian). Now if a directory is added we get `<directory> aggiunto cartella` while it should be `<directory> aggiunta cartella` (since "cartella"=directory is a feminine noun in Italian).

    add          => aggiunt[o]
    add dir      => aggiunt[a] cartella

So for 100% correct Italian translation 2 different `add` words are required.

This holds also for `removed`.